### PR TITLE
Remove tiller options because helmfile no longer supports Helm2

### DIFF
--- a/conduits.helmfile.yaml
+++ b/conduits.helmfile.yaml
@@ -121,12 +121,6 @@ releases:
     version: {{ $chartConfigs.appconduits.version }}
     {{ end }}
 
-    {{- /* Permit forced override of the default helm tillerNamespace (defined in helmDefaults.yaml) 
-          (set this via helmfile --state-values-set forceHelmTillerNamespace=[namespace]) */ -}}
-    {{ if hasKey $stateVals "forceHelmTillerNamespace" }}
-    tillerNamespace: {{ $stateVals.forceHelmTillerNamespace }}
-    {{ end }}
-
     {{- /* Permit forced override of the default helm timeout (defined in helmDefaults.yaml) 
           (set this via helmfile --state-values-set forceHelmTimeout=[N seconds]) */ -}}
     {{ if hasKey $stateVals "forceHelmTimeout" }}

--- a/deployments.helmfile.yaml
+++ b/deployments.helmfile.yaml
@@ -191,12 +191,6 @@ releases:
     installed: false
     {{ end }}
 
-    {{- /* Permit forced override of the default helm tillerNamespace (defined in helmDefaults.yaml)
-          (set this via helmfile --state-values-set forceHelmTillerNamespace=[namespace]) */ -}}
-    {{ if hasKey $stateVals "forceHelmTillerNamespace" }}
-    tillerNamespace: {{ $stateVals.forceHelmTillerNamespace }}
-    {{ end }}
-
     {{- /* Permit forced override of the default helm timeout (defined in helmDefaults.yaml)
           (set this via helmfile --state-values-set forceHelmTimeout=[N seconds]) */ -}}
     {{ if hasKey $stateVals "forceHelmTimeout" }}

--- a/helmDefaults.yaml
+++ b/helmDefaults.yaml
@@ -13,10 +13,6 @@ repositories:
 
 helmDefaults:
 
-  # this can be overriden per invocation via --state-values-set forceHelmTillerNamespace=<whatever>
-  tillerNamespace: {{ $targetCluster.helmDefaults.tillerNamespace }}
-
-  tillerless: {{ $targetCluster.helmDefaults.tillerless }}
   kubeContext: {{ $targetCluster.helmDefaults.kubeContext }}
   verify: {{ $targetCluster.helmDefaults.verify }}
   wait: {{ $targetCluster.helmDefaults.wait }}


### PR DESCRIPTION
Newer versions of helmfile do not support Helm 2.  Therefore `helmDefaults.tillerNamespace` and `helmDefaults.tillerless` no longer exist in helmDefaults